### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,26 @@
 
 # Docs Starter
 
-In this tutorial, you will learn how to create beautiful documentation in under 5 minutes using an OpenAPI/Swagger specification.
+Learn how to create beautiful documentation in under 5 minutes using an OpenAPI/Swagger specification.
 </div>
+
+## Requirements
+
+-   Node 18 or higher
+-   A [GitHub](https://github.com) account
 
 ---
 
 ### Step 1: Use this template
 
 1. Click on the "Use this template" button. You must be logged into GitHub.
-2. Create a new repository. Name is something like `fern-docs`.
+2. Choose the option to **create a new repository**. Name it `fern-docs`.
 
-### Step 2: Clone and open in your preferred code editor
+### Step 2: Clone and open the repo in your preferred code editor
 
 Clone your newly created repository and open it in your favorite code editor (e.g., VS Code).
 
-The files and folders discussed in the following steps will be inside a `fern` folder in your repository.
+The files and folders discussed in the following steps will be inside the `fern/` folder in your repository.
 
 ### Step 3: Customize organization name
 
@@ -44,6 +49,8 @@ instances:
 +  - url: MY_ORGANIZATION_NAME.docs.buildwithfern.com
 ```
 
+Leave the `version` number unchanged.
+
 ### Step 4: Install the Fern CLI
 
 Install the Fern CLI globally by running:
@@ -52,17 +59,9 @@ Install the Fern CLI globally by running:
 npm install -g fern-api
 ```
 
-The CLI commands in the following steps must be run from within the root of your repository.
+The CLI commands in the following steps must be run from within the root folder of your repository.
 
-### Step 5: Check that your OpenAPI specification is valid
-
-Run the following command to check that your OpenAPI specification is valid:
-
-```bash
-fern check
-```
-
-### Step 6: Generate your documentation
+### Step 5: Generate your documentation
 
 Run the following command:
 
@@ -72,7 +71,7 @@ fern generate --docs
 
 You will be prompted to log in and connect your GitHub account.
 
-Once the documentation is generated, you will receive a URL where your documentation is published. For example:
+Once the documentation is generated, you will receive the URL where your documentation is published. For example:
 
 ```shell
 ┌─
@@ -82,49 +81,30 @@ Once the documentation is generated, you will receive a URL where your documenta
 # OR
 
 ┌─
-│ ✓  MY_ORGANIZTION_NAME.docs.buildwithfern.com
+│ ✓  MY_ORGANIZATION_NAME.docs.buildwithfern.com
 └─
 ```
 
-### Step 7: (Optional) Add your own OpenAPI specification file
+### Step 6: Customize your documentation
 
-If you'd like to use your own OpenAPI file, run:
-
-```bash
-fern init --openapi URL_TO_YOUR_OPENAPI
-
-# OR
-
-fern init --openapi PATH_TO_YOUR_OPENAPI
-```
-
-Examples:
-
-```bash
-fern init --openapi https://raw.githubusercontent.com/fern-api/docs-starter-openapi/main/fern/openapi/openapi.yaml
-
-# OR
-
-fern init --openapi ../apis/openapi.yml
-```
-
-Confirm that you see a folder named `openapi` which contains the OpenAPI file you specified, in YAML format.
-
-*Note: Don't have an OpenAPI spec? Use Fern's simpler format to define your API.* [*Learn more*](https://github.com/fern-api/docs-starter-fern-definition)
-
-### Step 8: Customize your documentation
-
-Next, modify the markdown pages located in the `docs/pages` folder, such as the Welcome page.
-
-Further tailor your documentation to match your brand by adjusting settings in the `docs.yml` file. 
-
-To re-publish the updates to your documentation, run `fern generate --docs` again.
+You must run `fern generate --docs` after any modifications to re-generate and publish your documentation site.
 
 To preview updates to your documentation before publishing changes, run `fern generate --docs --preview`.
 
-Fern has a built-in component library for you to use. [Explore the components.](https://docs.buildwithfern.com/generate-docs/component-library/)
+To use your own OpenAPI specification file or to update the existing one:
+- Update or replace the OpenAPI specification file in the `openapi/` folder.
+- *Note: Don't have an OpenAPI spec? Use Fern's simpler format to define your API.* [*Learn more*](https://github.com/fern-api/docs-starter-fern-definition).
 
-### Step 9: Set up a custom domain
+To modify the other docs pages:
+- Update the Markdown files located in the `docs/pages/` folder, such as `welcome.mdx`.
+
+To modify site styles and navigation, or to add new pages:
+- See [Writing Content](/generate-docs/overview/writing-content).
+
+To learn about Fern's built-in component library you can use in Markdown:
+- See the [Component Library](/generate-docs/component-library/)
+- 
+### Step 7: Set up a custom domain
 
 If you wish to use a custom subdomain like `https://docs.YOUR_ORGANIZATION.com` or a subpath like `https://YOUR_ORGANIZATION.com/docs`, you can subscribe to the [Starter plan](https://buildwithfern.com/pricing). Once subscribed, update `docs.yml` with the custom domain configuration:
 
@@ -133,7 +113,7 @@ If you wish to use a custom subdomain like `https://docs.YOUR_ORGANIZATION.com` 
    custom-domain: docs.petstore-openapi.com
 ```
 
-### Step 10: Explore advanced features
+### Step 8: Explore advanced features
 
 For advanced documentation features and options, view the full [configuration docs](https://docs.buildwithfern.com/generate-docs/overview/configuration).
 
@@ -145,7 +125,7 @@ Good luck creating beautiful and functional documentation! 🌿
 
 Need help? Email us at (support@buildwithfern.com)[mailto:support@buildwithfern.com] or join our [Discord community](https://discord.com/invite/JkkXumPzcG).
 
-### Customer Showcase
+### Customer showcase
 
 Your docs can look this good:
 
@@ -155,4 +135,4 @@ Your docs can look this good:
 
 ### About OpenAPI (formerly Swagger)
 
-The OpenAPI specification is a format for describing REST APIs. The specification consists of a single JSON or YAML file. OpenAPI was previously known as Swagger. Fern supports both OpenAPI (3.x) and Swagger (2.x). We'll refer to the specification as OpenAPI throughout this guide.
+The OpenAPI specification is a format for describing REST APIs. The specification consists of a single JSON or YAML file. OpenAPI was previously known as Swagger. Fern supports both OpenAPI (3.x) and Swagger (2.x). We refer to the specification as OpenAPI throughout our documentation.


### PR DESCRIPTION
- Added Requirements section
- Had user name new repo 'fern-docs' instead of saying "something like", to simplify the experience by having them make less decisions
- Removed fern check since not needed for this QS as we supply the OpenAPI spec file, again to simplify the experience
- Removed step on using your own OpenAPI specification file. `fern init --openapi` command will fail if you run it the way that step suggests, with error message that `openapi/` folder already exists. Also, the step on customizing tells users how to use their own OpenAPI file.
- Edited step on customizing to provide more details and direct users to Writing Content page for information on how to change docs.yml for navigation and custom styles.