### PR TITLE
fix: missing text in openapi.yaml

### DIFF
--- a/fern/openapi/openapi.yaml
+++ b/fern/openapi/openapi.yaml
@@ -113,7 +113,7 @@ paths:
     get:
       tags:
         - pet
-      summary: Finds pets by status
+      summary: Finds Pets by status
       description: Multiple status values can be provided with comma separated strings
       operationId: findPetsByStatus
       parameters:

--- a/fern/openapi/openapi.yaml
+++ b/fern/openapi/openapi.yaml
@@ -113,7 +113,7 @@ paths:
     get:
       tags:
         - pet
-      summary:  by status
+      summary: Finds pets by status
       description: Multiple status values can be provided with comma separated strings
       operationId: findPetsByStatus
       parameters:


### PR DESCRIPTION
Looks like some text got accidentally deleted.