### PR TITLE
feat: use stable preview URLs and skip draft PRs

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -4,6 +4,7 @@ on: pull_request
 
 jobs:
   run:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -20,7 +21,7 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: |
-          OUTPUT=$(fern generate --docs --preview 2>&1) || true
+          OUTPUT=$(fern generate --docs --preview --preview-id ${{ github.event.pull_request.number }} 2>&1) || true
           echo "$OUTPUT"
           URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
           echo "Preview URL: $URL"


### PR DESCRIPTION
# feat: use stable preview URLs and skip draft PRs

## Summary

Part of a cross-repo feature to make docs preview URLs stable across PR commits (see [fern#10575](https://github.com/fern-api/fern/issues/10575)).

Two changes to the preview-docs workflow:

1. **Stable preview URLs**: Passes `--preview-id` with the PR number so every commit in the same PR reuses the same preview domain instead of generating a new one.
2. **Skip draft PRs**: Adds `if: github.event.pull_request.draft == false` to avoid wasting preview generations on draft PRs.

**⚠️ Depends on companion PRs being merged and released first:**
- fern-platform (server): accepts `previewId` and derives a deterministic domain
- fern CLI: adds `--preview-id` flag support

## Review & Testing Checklist for Human
- [ ] **Deployment order**: This workflow will fail if merged before the Fern CLI release that supports `--preview-id`. Confirm the CLI change is released before merging.
- [ ] Verify the draft PR skip condition (`github.event.pull_request.draft == false`) behaves correctly — note that PRs marked as "ready for review" after being draft will re-trigger the workflow.
- [ ] End-to-end test: open a PR against a repo using this workflow template, push two commits, and confirm both produce the same preview URL in the PR comment.

### Notes
- [Devin Session](https://app.devin.ai/sessions/05055ca6dd454792b00aef2bb33729e2)
- Requested by: @fern-support