### PR TITLE
chore: remove ai-search config

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -4,10 +4,6 @@ instances:
   - url: plantstore.docs.buildwithfern.com # update this to {yourorg}.docs.buildwithfern.com
     # custom-domain: plantstore.dev # specify your custom domain when you are ready to go live
 
-ai-search:
-  location:
-    - docs
-
 title: Fern Docs Starter
 
 layout:


### PR DESCRIPTION
## Summary

Removes the `ai-search` config block from `fern/docs.yml` as the team is moving away from this configuration. Per discussion in #project-docs-ftux.

```yaml
# Removed:
ai-search:
  location:
    - docs
```

## Review & Testing Checklist for Human

- [ ] Confirm that removing `ai-search` doesn't break the docs build (CI should validate this)
- [ ] Verify that search still works as expected on the deployed starter docs site after merge

### Notes

A matching PR is being created for `docs-starter-internal` with the same change.

Link to Devin session: https://app.devin.ai/sessions/b569dcd0b47f4153a4ed85e0cc7f524a
Requested by: @sbawabe