### PR TITLE
chore: bump CLI version from 4.35.0 to 4.63.0

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "plantstore",
-  "version": "4.35.0"
+  "version": "4.63.0"
 }


### PR DESCRIPTION
## Summary

Bumps the pinned Fern CLI version in `fern.config.json` from `4.35.0` to `4.63.0`.

Version `4.35.0` predates CI metadata support (`X-CI-Source` / `X-CLI-Version` headers, added in `4.38.0`), so repos forked from this starter template don't send deployment metadata to FDR. This means the dashboard Activity Log shows blank Source columns and no CLI version badges for those deployments.

Upgrading to `4.63.0` (latest) also picks up concurrent publish protection and deployer author attribution (`4.55.0`+).

Companion PR: https://github.com/fern-api/fern-platform/pull/9559 (same bump in the dashboard's inline docs-starter template used for Postman onboarding).

## Review & Testing Checklist for Human

- [ ] Confirm `4.63.0` is a stable, published CLI release (it's the latest entry in `fern-api/fern` `packages/cli/cli/versions.yml`)
- [ ] Run `fern generate --docs` (or `fern check`) against this repo with the new version to verify it works end-to-end

### Notes

- This only affects **new** repos that fork/clone the starter. Existing repos still have their own pinned version.

Link to Devin session: https://app.devin.ai/sessions/7a0d9a8466ed49d78fa15bedb445b684
Requested by: @matlegault
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs-starter/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
