### PR TITLE
feat: improve preview PR comment with branded design

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -64,13 +64,29 @@ jobs:
 
       - name: Create comment content
         run: |
-          echo ":herb: **Preview your docs:** <${{ steps.generate-docs.outputs.preview_url }}>" > comment.md
-          
+          PREVIEW_URL="${{ steps.generate-docs.outputs.preview_url }}"
+          cat > comment.md << EOF
+          <div align="center">
+          <a href="https://buildwithfern.com"><img src="https://raw.githubusercontent.com/fern-api/docs-starter/main/fern/docs/assets/fern-logo-primary.svg" height="30" alt="Fern" /></a>
+          <h3>✅ Preview Ready</h3>
+          <strong><a href="$PREVIEW_URL">Visit Preview →</a></strong>
+          </div>
+
+          ---
+          EOF
+
           if [ -n "${{ steps.page-links.outputs.page_links }}" ]; then
             echo "" >> comment.md
-            echo "Here are the markdown pages you've updated:" >> comment.md
+            echo "<details>" >> comment.md
+            echo "<summary>📄 <strong>Changed pages</strong></summary>" >> comment.md
+            echo "" >> comment.md
             echo "${{ steps.page-links.outputs.page_links }}" >> comment.md
+            echo "" >> comment.md
+            echo "</details>" >> comment.md
+            echo "" >> comment.md
           fi
+
+          echo '<sub>🌿 Deployed with <a href="https://buildwithfern.com">Fern</a></sub>' >> comment.md
 
       - name: Post PR comment
         uses: thollander/actions-comment-pull-request@v2.4.3


### PR DESCRIPTION
## Summary

Redesigns the PR preview comment to be more visually appealing and branded, addressing customer feedback that the current comment is too plain.

**Before:**
```
🌿 Preview your docs: <URL>
```

**After:**
The new comment features:
- Centered Fern logo for brand recognition
- Clear `✅ Preview Ready` status heading
- Bold, prominent "Visit Preview →" link
- Collapsible "Changed pages" section using `<details>`
- Subtle "Deployed with Fern" footer branding

The design uses GitHub-compatible HTML (`<div align="center">`, `<h3>`, `<details>`) that renders reliably in PR comments.

## Review & Testing Checklist for Human
- [ ] Verify the new comment renders correctly in a real PR by triggering the workflow on a test branch
- [ ] Confirm the Fern logo SVG renders properly in the GitHub comment (from `raw.githubusercontent.com`)

### Notes
This is part of a coordinated change across 3 repos: `docs-starter` (this PR), `fern-platform` (template test fixture), and `docs` (documentation examples).

Link to Devin session: https://app.devin.ai/sessions/064c68649dc6458d8c73fad00c829285
Requested by: @Ryan-Amirthan