### PR TITLE
ci: pin GitHub Actions workflows to Node.js 24

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Setup Fern CLI
         uses: fern-api/setup-fern-cli@v1
 

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -10,7 +10,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Fetch full history for git diff
 
@@ -20,7 +20,7 @@ jobs:
           git checkout pr-${{ github.event.pull_request.number }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
 

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -19,6 +19,11 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }}
           git checkout pr-${{ github.event.pull_request.number }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Setup Fern CLI
         uses: fern-api/setup-fern-cli@v1
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,10 +11,10 @@ jobs:
     if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/heads/main') && github.run_number > 1 }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Setup Fern CLI
         uses: fern-api/setup-fern-cli@v1
 


### PR DESCRIPTION
## Summary

Pins the Fern CLI's runtime in all three workflows (`check.yml`, `preview-docs.yml`, `publish-docs.yml`) to Node.js 24:

- Adds an explicit `actions/setup-node@v5` step pinned to `node-version: "24"` before `fern-api/setup-fern-cli@v1`.
- Bumps `actions/checkout` from v4 → v5.
- Bumps `actions/setup-node` to v5 directly (skipping the v4 step).

Previously the workflows had no Node setup step and silently inherited whatever Node version `ubuntu-latest` ships with by default (Node 20). The `setup-fern-cli` action does not install Node itself — it just checks that `node`/`npm` are on PATH and globally installs the CLI — so the Fern CLI's runtime was tied to the runner image.

CI on this PR confirms: `Setup Node.js → node-version: 24 → Found in cache @ /opt/hostedtoolcache/node/24.14.1/x64 → Installed Fern CLI version 5.23.3 → fern generate --docs --preview` succeeds end-to-end.

The remaining runner deprecation warning is for the unowned `thollander/actions-comment-pull-request@v2.4.3`, which still runs on Node 20. v3 of that action exists but introduces breaking input renames (`filePath` → `file-path`, `comment_tag` → `comment-tag`, etc.), so it's intentionally out of scope here.

## Review & Testing Checklist for Human

- [ ] Confirm Node 24 (vs. `lts/*` / `24.x` / a more specific minor) is what we want pinned long-term
- [ ] Confirm we're OK leaving `thollander/actions-comment-pull-request@v2.4.3` on Node 20 for now (or do you want a follow-up PR to bump to v3 with the parameter renames?)
- [ ] After merge, `fern check` / preview-docs / publish-docs CI runs on real customer repos forked from this starter should show `Setup Node.js → 24.x` in the logs

### Notes

`fern-api/docs-starter-internal` (the repo the FTUX onboarding flow actually clones from, pinned via `ACTIVE_ONBOARDING_PUBLISH_STARTER_VERSION` in `fern-platform`) has a sibling PR with the same change. After it lands, the `commitSha` pin in `packages/fern-dashboard/src/app/api/onboarding-docs/publish/starterVersion.ts` should be bumped so new onboarding-generated repos pick up Node 24.

Link to Devin session: https://app.devin.ai/sessions/f891c25f97074eaba936dd3cf0d3b7d3
Requested by: @thesandlord