### PR TITLE
ci: replace thollander/actions-comment-pull-request with inline gh api

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -78,8 +78,26 @@ jobs:
           fi
 
       - name: Post PR comment
-        uses: thollander/actions-comment-pull-request@v2.4.3
-        with:
-          filePath: comment.md
-          comment_tag: preview-docs
-          mode: upsert
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          MARKER="<!-- fern-preview-docs -->"
+          {
+            cat comment.md
+            printf '\n%s\n' "$MARKER"
+          } > comment-with-marker.md
+
+          # Upsert by looking up an existing comment that carries our hidden marker.
+          EXISTING_ID=$(gh api --paginate \
+            "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq "[.[] | select(.body | contains(\"$MARKER\"))][0].id // empty")
+
+          jq -Rn --rawfile body comment-with-marker.md '{body: $body}' > payload.json
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING_ID" --input payload.json
+          else
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" --input payload.json
+          fi


### PR DESCRIPTION
## Summary

Replaces the `thollander/actions-comment-pull-request@v2.4.3` third-party action in `preview-docs.yml` with an inline `gh api` upsert.

After PR #117 bumped `actions/checkout` and `actions/setup-node` to v5 (Node 24 runtime), this action was the only piece of `preview-docs.yml` still pinned to Node.js 20, and the only remaining source of the runner's "Node.js 20 actions are deprecated" warning. The third-party v3 release fixes the Node version but introduces breaking input renames (`filePath` → `file-path`, `comment_tag` → `comment-tag`) and slightly different delete-mode semantics — replacing it inline is cheaper than chasing those breaks and removes the dependency entirely.

The replacement preserves the existing upsert behavior:
1. Build the comment body (`comment.md` from the previous "Create comment content" step) and append a hidden HTML marker `<!-- fern-preview-docs -->` for deduplication.
2. List the PR's issue comments via `gh api ... --paginate` and select the first comment containing the marker.
3. If one exists, `PATCH /repos/{owner}/{repo}/issues/comments/{id}`; otherwise `POST /repos/{owner}/{repo}/issues/{pr}/comments`.

Uses `GITHUB_TOKEN` (already in the runner env) with the existing `pull-requests: write` permission — no new secrets, no new permissions, no new tools (`gh` and `jq` are both pre-installed on `ubuntu-latest`).

## Review & Testing Checklist for Human

- [ ] Open a throwaway PR against the merged starter and confirm the preview comment is posted once on the first push and updated in place (not duplicated) on subsequent pushes
- [ ] Any existing open PR that already had a thollander-authored comment will get a fresh `fern-preview-docs`-tagged comment alongside the old one on the next push — that's expected (different marker, no orphaning), but worth a glance if you have a long-lived preview PR open

### Notes

Same change applied to `fern-api/docs-starter-internal` in a sibling PR to keep the two starters in sync. After both land, the `commitSha` pin in `packages/fern-dashboard/src/app/api/onboarding-docs/publish/starterVersion.ts` in `fern-platform` should be bumped to pick up the change for newly-onboarded customer repos.

Link to Devin session: https://app.devin.ai/sessions/f891c25f97074eaba936dd3cf0d3b7d3
Requested by: @thesandlord