### PR TITLE
chore: upgrade fern CLI to 5.35.4

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "plantstore",
-  "version": "4.35.0"
+  "version": "5.35.4"
 }


### PR DESCRIPTION
## Summary
Upgrades the Fern CLI version in `fern/fern.config.json` from `4.35.0` to `5.35.4` (latest).

## Review & Testing Checklist for Human
- [ ] Verify `fern check` passes with the new CLI version
- [ ] Run `fern docs dev` locally to confirm the docs still render correctly

### Notes
Companion PR in `fern-api/docs-starter-internal` also bumps the CLI version for the FTUX onboarding flow.

Link to Devin session: https://app.devin.ai/sessions/1fc1c8617e7e4828acf692c1b683baa8
Requested by: @Ryan-Amirthan