### PR TITLE
Enable Install skills page action pointing at fern-api/skills

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -85,6 +85,19 @@ theme:
   page-actions: toolbar
   footer-nav: minimal
 
+page-actions:
+  options:
+    skills:
+      title: Install agent skills
+      description: Skills for authoring Fern docs, maintained in our skills repo.
+      learn-more-url: https://buildwithfern.com/learn/docs/ai/agent-skills
+      repository: https://github.com/fern-api/skills
+      install-command: npx skills add fern-api/skills --skill fern-docs
+      skills:
+        - name: fern-docs
+          description: "Author and edit Fern documentation: MDX pages, navigation, docs.yml config, custom components, landing pages, and changelog entries."
+          url: https://github.com/fern-api/skills/tree/main/skills/fern-docs
+
 logo:
   dark: docs/assets/logo-dark.svg
   light: docs/assets/logo.svg

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "plantstore",
-  "version": "5.35.4"
+  "version": "5.47.1"
 }


### PR DESCRIPTION
Adds a top-level `page-actions.options.skills` block to `fern/docs.yml`, enabling the "Install skills" page action and pointing it at Fern's own skills repo ([fern-api/skills](https://github.com/fern-api/skills)).

The modal surfaces the `fern-docs` skill with the `npx skills add fern-api/skills --skill fern-docs` install command, a "View source" link to the repo, and a "Learn more" link to the agent-skills docs. This uses the schema added in fern-api/fern#16446 and rendered by fern-api/fern-platform#11947 — once this site serves a `/.well-known` skills manifest, the modal will swap the hand-listed skill for the served one automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs-starter/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->