### PR TITLE
chore: remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-* @Ryan-Amirthan
-


### PR DESCRIPTION
## Summary

Removes `.github/CODEOWNERS` so it doesn't propagate to repos created from this template.

Link to Devin session: https://app.devin.ai/sessions/ce52533478ab464f9c9bcd4026b94afe
Requested by: @Ryan-Amirthan