### PR TITLE
Upgrade dependencies: Fern CLI 5.20.0 → 5.69.0 and GitHub Actions

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "plantstore",
-  "version": "5.35.4"
+  "version": "5.20.0"
 }

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "plantstore",
-  "version": "5.20.0"
+  "version": "5.69.0"
 }


### PR DESCRIPTION
This PR upgrades the Fern CLI version from 5.20.0 to 5.69.0 (latest stable) and bumps GitHub Actions dependencies:\n\n- actions/checkout: v5 → v7\n- actions/setup-node: v5 → v6\n\nAll changes have been validated with Found 0 errors and 2 warnings in 0.000 seconds. Run fern check --warnings to print out the warnings not shown..