### PR TITLE
Upgrade Fern CLI and GitHub Actions

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "plantstore",
-  "version": "5.35.4"
+  "version": "5.20.0"
 }

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "plantstore",
-  "version": "5.20.0"
+  "version": "5.69.0"
 }


### PR DESCRIPTION
Bump Fern CLI 5.20.0 → latest; bump Action pins. Verified with fern check. Demo PR — not for merge.